### PR TITLE
Honour int_to_bytestring's padding parameter

### DIFF
--- a/lib/rotp/otp.rb
+++ b/lib/rotp/otp.rb
@@ -50,7 +50,7 @@ module ROTP
         result << (int & 0xFF).chr
         int >>=  8
       end
-      result.reverse.join.rjust(8, 0.chr)
+      result.reverse.join.rjust(padding, 0.chr)
     end
 
   end


### PR DESCRIPTION
OTP::int_to_bytestring doesn't currently use it's padding parameter.
