### PR TITLE
Bug fix: TOTP#verify_with_drift produced wrong result when drift was not

### DIFF
--- a/lib/rotp/totp.rb
+++ b/lib/rotp/totp.rb
@@ -38,8 +38,10 @@ module ROTP
     # @param [Integer] drift the number of seconds that the client
     #     and server are allowed to drift apart
     def verify_with_drift(otp, drift, time = Time.now)
-      drift_intervals = drift / interval
-      (-drift_intervals..drift_intervals).any? { |n|  verify(otp, time + n * interval) }
+      time = time.to_i
+      times = (time-drift..time+drift).step(interval).to_a
+      times << time + drift if times.last < time + drift
+      times.any? { |ti| verify(otp, ti) }
     end
 
     # Returns the provisioning URI for the OTP

--- a/spec/totp_spec.rb
+++ b/spec/totp_spec.rb
@@ -26,10 +26,18 @@ describe ROTP::TOTP do
       subject.verify_with_drift(subject.at(@now - 30), 60, @now).should be_true
     end
     it "should verify a slightly new number" do
-      subject.verify_with_drift(subject.at(@now - 60), 60, @now).should be_true
+      subject.verify_with_drift(subject.at(@now + 60), 60, @now).should be_true
     end
     it "should reject a number that is outside the allowed drift" do
       subject.verify_with_drift(subject.at(@now - 60), 30, @now).should be_false
+    end
+    context "with drift that is not a multiple of the TOTP interval" do
+      it "should verify a slightly old number" do
+        subject.verify_with_drift(subject.at(@now - 45), 45, @now).should be_true
+      end
+      it "should verify a slightly new number" do
+        subject.verify_with_drift(subject.at(@now + 40), 40, @now).should be_true
+      end
     end
   end
 end


### PR DESCRIPTION
... a multiple of interval

My bad.  Shouldn't have coded the original method at 2 am, I guess.  I realised my mistake when I woke up, but was too busy yesterday.

I'll try not to bother you for a while.
