### PR TITLE
Produce fixed-length TOTPs, especially for sites that require six digits

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,7 +25,9 @@ This is compatible with Google Authenticator apps available for Android and iPho
 ### Time based OTP's
 
     totp = ROTP::TOTP.new("base32secret3232")
-    totp.now # => 492039
+    totp.now # => 92039
+    totp.now_padded # => "092039"
+    totp.now_padded(10) # => "0000092039"
 
     # OTP verified for current time
     totp.verify(492039) # => true
@@ -81,13 +83,14 @@ Now run the following and compare the output
 
     git shortlog -s -n
 
-        37  Mark Percival
-         5  David Vrensk
-         1  Nathan Reynolds
-         1  Shai Rosenfeld
-         1  Shai Rosenfeld & Michael Brodhead
-         1  Michael Brodhead & Shai Rosenfeld
-         1  Micah Gates
+        41  Mark Percival
+        6  David Vrensk
+        1  Michael Brodhead & Shai Rosenfeld
+        1  Nathan Reynolds
+        1  Shai Rosenfeld
+        1  Dave Williams
+        1  Shai Rosenfeld & Michael Brodhead
+        1  Micah Gates
 
 ### Changelog
 

--- a/lib/rotp/totp.rb
+++ b/lib/rotp/totp.rb
@@ -26,6 +26,18 @@ module ROTP
       generate_otp(timecode(Time.now))
     end
 
+    # Generate the current time OTP with zero-padding
+    # Useful for consumers expecting six digits
+    # @param [Integer] pad_to Zero-pad to this many digits
+    # @return [String] the padded OTP as a string
+    def now_padded(pad_to = 6)
+      otp = now.to_s
+      while otp.length < pad_to
+        otp = "0" + otp
+      end
+      otp
+    end
+
     # Verifies the OTP passed in against the current time OTP
     # @param [String/Integer] otp the OTP to check against
     def verify(otp, time = Time.now)


### PR DESCRIPTION
A quick hack, if it's useful to me then it's probably going to be useful to someone else. Because we're zero-prefixing, TOTP#now_padded returns a string rather than TOTP#now which returns an integer.
