### PR TITLE
Remove deprecation warnings on ruby 2.1

### DIFF
--- a/lib/rotp/otp.rb
+++ b/lib/rotp/otp.rb
@@ -22,7 +22,7 @@ module ROTP
     # based on the Unix timestamp
     def generate_otp(input, padded=false)
       hmac = OpenSSL::HMAC.digest(
-        OpenSSL::Digest::Digest.new(digest),
+        OpenSSL::Digest.new(digest),
         byte_secret,
         int_to_bytestring(input)
       )


### PR DESCRIPTION
This removes deprecation warnings that I just noticed on ruby 2.1:

```
Digest::Digest is deprecated; use Digest
```

I tested this on ruby 1.9.3, 2.0, 2.1 and jruby-1.7.9 and all tests pass. 
