### PR TITLE
Mention TOTP issuer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ sleep 30
 totp.verify("492039") # => false
 ```
 
+Optionally, you can provide an issuer which will be used as a title in Google Authenticator.
+
+```ruby
+totp = ROTP::TOTP.new("base32secret3232", issuer: "Google")
+```
+
 ### Counter based OTP's
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ totp.verify("492039") # => false
 Optionally, you can provide an issuer which will be used as a title in Google Authenticator.
 
 ```ruby
-totp = ROTP::TOTP.new("base32secret3232", issuer: "Google")
+totp = ROTP::TOTP.new("base32secret3232", issuer: "My Service")
 ```
 
 ### Counter based OTP's


### PR DESCRIPTION
Hello, first of all, thanks for your work on this gem!

I've been trying to get Google Authenticator to display a title just as it's common when setting up 2-step authentication services. Since I didn't find any documentation about it I had to dig into the codebase and discover the `opts[:issuer]` so hopefully this PR will make it slightly easier to people to add this functionality.

I've attached a couple of screenshots that clarify my original intent.

**Without issuer**
![before](https://cloud.githubusercontent.com/assets/807237/6553478/0b66f2a0-c649-11e4-809a-c03c55146804.PNG)

**With an issuer**
![after](https://cloud.githubusercontent.com/assets/807237/6553481/1ad7239a-c649-11e4-8017-46fc0d9ca7ec.PNG)
