### PR TITLE
Reverse order of secret and issuer params in provisioning URL.

### DIFF
--- a/lib/rotp/totp.rb
+++ b/lib/rotp/totp.rb
@@ -54,7 +54,7 @@ module ROTP
     # @return [String] provisioning uri
     def provisioning_uri(name)
       encode_params("otpauth://totp/#{URI.encode(name)}",
-                    :period => (interval==30 ? nil : interval), :issuer => issuer, :secret => secret)
+                    :secret => secret, :period => (interval==30 ? nil : interval), :issuer => issuer)
     end
 
     private


### PR DESCRIPTION
See https://gitlab.com/gitlab-org/gitlab-ce/issues/1679.

Apparently the Windows Phone Authenticator app only recognizes the provisioning URL when the issuer comes _after_ the secret. Bad coding on the Windows Phone app's part, I guess, but it's easier to change this in rotp than it is to change it in the app.