### PR TITLE
MUST NOT accept subsequent OTPs, after valid OTP verification

### DIFF
--- a/spec/lib/rotp/totp_spec.rb
+++ b/spec/lib/rotp/totp_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe ROTP::TOTP do
         it 'is true' do
           expect(totp.verify('102705')).to be_truthy
         end
+
+        it 'can\'t be verified more than once' do
+          expect(totp.verify('102705')).to be_truthy
+          expect(totp.verify('102705')).to be_falsey
+          expect(totp.verify('102705')).to be_falsey
+        end
       end
 
       context 'wrong time based OTP' do

--- a/spec/lib/rotp/totp_spec.rb
+++ b/spec/lib/rotp/totp_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe ROTP::TOTP do
 
       it 'is true' do
         expect(verification).to be_truthy
+        expect(totp.verify_with_drift(token, drift, now)).to be_falsey
       end
     end
 
@@ -172,6 +173,7 @@ RSpec.describe ROTP::TOTP do
 
       it 'is true' do
         expect(verification).to be_truthy
+        expect(totp.verify_with_drift(token, drift, now)).to be_falsey
       end
     end
 
@@ -181,6 +183,7 @@ RSpec.describe ROTP::TOTP do
 
       it 'is true' do
         expect(verification).to be_truthy
+        expect(totp.verify_with_drift(token, drift, now)).to be_falsey
       end
     end
 
@@ -200,6 +203,7 @@ RSpec.describe ROTP::TOTP do
 
         it 'is true' do
           expect(verification).to be_truthy
+          expect(totp.verify_with_drift(token, drift, now)).to be_falsey
         end
       end
 
@@ -209,6 +213,7 @@ RSpec.describe ROTP::TOTP do
 
         it 'is true' do
           expect(verification).to be_truthy
+          expect(totp.verify_with_drift(token, drift, now)).to be_falsey
         end
       end
     end


### PR DESCRIPTION
This is in compliance with [RFC 6238](https://tools.ietf.org/html/rfc6238), Section 5.2, final paragraph:

> Note that a prover may send the same OTP inside a given time-step
> window multiple times to a verifier.  The verifier MUST NOT accept
> the second attempt of the OTP after the successful validation has
> been issued for the first OTP, which ensures one-time only use of an
> OTP.

The TOTP class has been amended to have a hash of consumed or "burned" one time passwords at their associated time step. For a given OTP, it is added to the hash if successfully validated and isn't already in the hash for that timestep.

This addresses #44.