### PR TITLE
Work with ruby 2.3's --enable-frozen-string-literal

### DIFF
--- a/lib/rotp/base32.rb
+++ b/lib/rotp/base32.rb
@@ -14,7 +14,7 @@ module ROTP
       end
 
       def random_base32(length=16)
-        b32 = ''
+        b32 = String.new
         OpenSSL::Random.random_bytes(length).each_byte do |b|
           b32 << CHARS[b % 32]
         end

--- a/lib/rotp/otp.rb
+++ b/lib/rotp/otp.rb
@@ -67,7 +67,7 @@ module ROTP
 
     # A very simple param encoder
     def encode_params(uri, params)
-      params_str = "?"
+      params_str = String.new("?")
       params.each do |k,v|
         if v
           params_str << "#{k}=#{CGI::escape(v.to_s)}&"


### PR DESCRIPTION
These changes are the minimal ones necessary to allow Rodauth's specs
to pass. There may well be other changes that are required.