### PR TITLE
Include issuer in TOTP provisioning URL as well as query string

### DIFF
--- a/lib/rotp/totp.rb
+++ b/lib/rotp/totp.rb
@@ -51,9 +51,14 @@ module ROTP
     # This can then be encoded in a QR Code and used
     # to provision the Google Authenticator app
     # @param [String] name of the account
-    # @return [String] provisioning uri
+    # @return [String] provisioning URI
     def provisioning_uri(name)
-      encode_params("otpauth://totp/#{URI.encode(name)}",
+      # The format of this URI is documented at:
+      # https://github.com/google/google-authenticator/wiki/Key-Uri-Format
+      # For compatibility the issuer appears both before that account name and also in the
+      # query string.
+      issuer_string = issuer.nil? ? "" : "#{URI.encode(issuer)}:"
+      encode_params("otpauth://totp/#{issuer_string}#{URI.encode(name)}",
                     :secret => secret, :period => (interval==30 ? nil : interval), :issuer => issuer)
     end
 

--- a/spec/lib/rotp/totp_spec.rb
+++ b/spec/lib/rotp/totp_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe ROTP::TOTP do
       let(:totp)  { ROTP::TOTP.new 'JBSWY3DPEHPK3PXP', issuer: 'FooCo' }
 
       it 'has the correct format' do
-        expect(uri).to match %r{\Aotpauth:\/\/totp.+}
+        expect(uri).to match %r{\Aotpauth:\/\/totp/FooCo:.+}
       end
 
       it 'includes the secret as parameter' do


### PR DESCRIPTION
According the google authenticator docs the issuer should be
included both in the URL itself as well as in the query
string. See:
https://github.com/google/google-authenticator/wiki/Key-Uri-Format#issuer