### PR TITLE
Use SecureRandom rather than OpenSSL::Random

### DIFF
--- a/lib/rotp.rb
+++ b/lib/rotp.rb
@@ -1,6 +1,6 @@
 require 'cgi'
 require 'uri'
-require 'openssl'
+require 'securerandom'
 require 'rotp/base32'
 require 'rotp/otp'
 require 'rotp/hotp'

--- a/lib/rotp/base32.rb
+++ b/lib/rotp/base32.rb
@@ -15,7 +15,7 @@ module ROTP
 
       def random_base32(length=16)
         b32 = String.new
-        OpenSSL::Random.random_bytes(length).each_byte do |b|
+        SecureRandom.random_bytes(length).each_byte do |b|
           b32 << CHARS[b % 32]
         end
         b32


### PR DESCRIPTION
SecureRandom uses OpenSSL::Random under the hood anyway but
is apparently a more secure:
https://bugs.ruby-lang.org/issues/4579