### PR TITLE
Add digits paramater to provisioning URI

### DIFF
--- a/lib/rotp/hotp.rb
+++ b/lib/rotp/hotp.rb
@@ -38,7 +38,12 @@ module ROTP
     # @param [Integer] initial_count starting counter value, defaults to 0
     # @return [String] provisioning uri
     def provisioning_uri(name, initial_count=0)
-      encode_params("otpauth://hotp/#{URI.encode(name)}", :secret=>secret, :counter=>initial_count)
+      params = {
+        secret: secret,
+        counter: initial_count,
+        digits: digits == DEFAULT_DIGITS ? nil : digits
+      }
+      encode_params("otpauth://hotp/#{URI.encode(name)}", params)
     end
 
   end

--- a/lib/rotp/otp.rb
+++ b/lib/rotp/otp.rb
@@ -1,6 +1,7 @@
 module ROTP
   class OTP
     attr_reader :secret, :digits, :digest
+    DEFAULT_DIGITS = 6
 
     # @param [String] secret in the form of base32
     # @option options digits [Integer] (6)
@@ -11,7 +12,7 @@ module ROTP
     #     Google Authenticate only supports 'sha1' currently
     # @returns [OTP] OTP instantiation
     def initialize(s, options = {})
-      @digits = options[:digits] || 6
+      @digits = options[:digits] || DEFAULT_DIGITS
       @digest = options[:digest] || "sha1"
       @secret = s
     end

--- a/lib/rotp/totp.rb
+++ b/lib/rotp/totp.rb
@@ -58,8 +58,13 @@ module ROTP
       # For compatibility the issuer appears both before that account name and also in the
       # query string.
       issuer_string = issuer.nil? ? "" : "#{URI.encode(issuer)}:"
-      encode_params("otpauth://totp/#{issuer_string}#{URI.encode(name)}",
-                    :secret => secret, :period => (interval==30 ? nil : interval), :issuer => issuer)
+      params = {
+        secret: secret,
+        period: interval == 30 ? nil : interval,
+        issuer: issuer,
+        digits: digits == DEFAULT_DIGITS ? nil : digits,
+      }
+      encode_params("otpauth://totp/#{issuer_string}#{URI.encode(name)}", params)
     end
 
     private

--- a/spec/lib/rotp/hotp_spec.rb
+++ b/spec/lib/rotp/hotp_spec.rb
@@ -82,6 +82,20 @@ RSpec.describe ROTP::HOTP do
     it 'includes the secret as parameter' do
       expect(params['secret'].first).to eq 'a' * 32
     end
+
+    context 'with default digits' do
+      it 'does not include digits parameter with default digits' do
+        expect(params['digits'].first).to be_nil
+      end
+    end
+
+    context 'with non-default digits' do
+      let(:hotp) { ROTP::HOTP.new('a' * 32, digits: 8) }
+
+      it 'includes digits parameter' do
+        expect(params['digits'].first).to eq '8'
+      end
+    end
   end
 
   describe '#verify_with_retries' do

--- a/spec/lib/rotp/totp_spec.rb
+++ b/spec/lib/rotp/totp_spec.rb
@@ -97,6 +97,20 @@ RSpec.describe ROTP::TOTP do
       end
     end
 
+    context 'with default digits' do
+      it 'does does not include digits parameter' do
+        expect(params['digits'].first).to be_nil
+      end
+    end
+
+    context 'with non-default digits' do
+      let(:totp)  { ROTP::TOTP.new 'JBSWY3DPEHPK3PXP', digits: 8 }
+
+      it 'does does not include digits parameter' do
+        expect(params['digits'].first).to eq '8'
+      end
+    end
+
     context 'with issuer' do
       let(:totp)  { ROTP::TOTP.new 'JBSWY3DPEHPK3PXP', issuer: 'FooCo' }
 


### PR DESCRIPTION
Include the digits paramater in the URI generated
by #provisioning_uri when #digits is a non-default
value.  Add tests for this for totp and hotp for
default and non-default number of digits.