### PR TITLE
Fix uninitialized error on JRuby

### DIFF
--- a/lib/rotp/otp.rb
+++ b/lib/rotp/otp.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+
 module ROTP
   class OTP
     attr_reader :secret, :digits, :digest


### PR DESCRIPTION
```
NameError: uninitialized constant ROTP::OTP::OpenSSL
  const_missing at org/jruby/RubyModule.java:3344
    generate_otp at /Users/kes/.rbenv/versions/jruby-9.1.7.0/lib/ruby/gems/shared/gems/rotp-3.3.0/lib/rotp/otp.rb:25
            now at /Users/kes/.rbenv/versions/jruby-9.1.7.0/lib/ruby/gems/shared/gems/rotp-3.3.0/lib/rotp/totp.rb:29
         <main> at //Users/kes/.dotfiles/bin/totp:31
```