### PR TITLE
Additional check for negative numbers in #int_to_bytestring

### DIFF
--- a/lib/rotp/otp.rb
+++ b/lib/rotp/otp.rb
@@ -58,6 +58,10 @@ module ROTP
     # along with the secret
     #
     def int_to_bytestring(int, padding = 8)
+      unless int >= 0
+        raise ArgumentError, "#int_to_bytestring requires a positive number"
+      end
+
       result = []
       until int == 0
         result << (int & 0xFF).chr

--- a/lib/rotp/totp.rb
+++ b/lib/rotp/totp.rb
@@ -20,6 +20,7 @@ module ROTP
       unless time.class == Time
         time = Time.at(time.to_i)
       end
+
       generate_otp(timecode(time), padding)
     end
 

--- a/spec/lib/rotp/totp_spec.rb
+++ b/spec/lib/rotp/totp_spec.rb
@@ -161,6 +161,21 @@ RSpec.describe ROTP::TOTP do
 
   end
 
+  describe 'invalid_verification with nil time as argument' do
+    let(:verification) { totp.verify_with_drift token, drift, nil }
+
+    context 'positive drift' do
+      let(:token) { totp.at now - 30 }
+      let(:drift) { 60 }
+
+      it 'raises error' do
+        expect do
+          verification
+        end.to raise_error(ArgumentError)
+      end
+    end
+  end
+
   describe '#verify_with_drift' do
     let(:verification) { totp.verify_with_drift token, drift, now }
     let(:drift) { 0 }


### PR DESCRIPTION
Hey guys,

we encountered an infinite loop by mistake. The params passed to `verify_with_drift` (https://github.com/mdp/rotp/blob/master/lib/rotp/totp.rb#L43) had `time` as `nil` and `drift` as a positive integer.  As the result, the ranges produced a negative number. `int_to_bytestring` has an does a 8 bit shift of the value passed to it. However, if it's a negative number, it goes into the infinite loop.
Although a developer must provide valid input, there could be time of mistakes like we did. I believe that by providing additional validation to this case, we can quickly pin-point a developer where the invalid input is.
