### PR TITLE
Require Openssl to fix usage with ruby 2.5.

### DIFF
--- a/lib/rotp.rb
+++ b/lib/rotp.rb
@@ -1,6 +1,7 @@
 require 'cgi'
 require 'uri'
 require 'securerandom'
+require 'openssl'
 require 'rotp/base32'
 require 'rotp/otp'
 require 'rotp/hotp'


### PR DESCRIPTION
Apparently in ruby 2.5.0 openssl has to be required explicity to avoid the following exception. This commit introduces that.

```ruby
.../lib/rotp/otp.rb:25:in `generate_otp': uninitialized constant ROTP::OTP::OpenSSL (NameError)```