### PR TITLE
Allow decoding base32 with padding

### DIFF
--- a/lib/rotp/base32.rb
+++ b/lib/rotp/base32.rb
@@ -5,6 +5,7 @@ module ROTP
 
     class << self
       def decode(str)
+        str = str.tr('=','')
         output = []
         str.scan(/.{1,8}/).each do |block|
           char_array = decode_block(block).map{|c| c.chr}

--- a/spec/lib/rotp/base32_spec.rb
+++ b/spec/lib/rotp/base32_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe ROTP::Base32 do
         expect(ROTP::Base32.decode('234BCDEFG').unpack('H*').first).to eq 'd6f8110c8530'
         expect(ROTP::Base32.decode('234BCDEFG234BCDEFG').unpack('H*').first).to eq 'd6f8110c8536b7c0886429'
       end
+
+      context 'with padding' do
+        it 'correctly decodes a string' do
+        expect(ROTP::Base32.decode('F==').unpack('H*').first).to eq '28'
+        end
+      end
     end
   end
 end

--- a/spec/lib/rotp/base32_spec.rb
+++ b/spec/lib/rotp/base32_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ROTP::Base32 do
 
       context 'with padding' do
         it 'correctly decodes a string' do
-        expect(ROTP::Base32.decode('F==').unpack('H*').first).to eq '28'
+          expect(ROTP::Base32.decode('F==').unpack('H*').first).to eq '28'
         end
       end
     end


### PR DESCRIPTION
Some services will pad the base32 string with `=` signs.

ROTP will throw an error if it sees any equal signs in a base32 string.

This PR fixes that.