### PR TITLE
support image parameter for provisioning URIs

### DIFF
--- a/lib/rotp/totp.rb
+++ b/lib/rotp/totp.rb
@@ -1,13 +1,14 @@
 module ROTP
   DEFAULT_INTERVAL = 30
   class TOTP < OTP
-    attr_reader :interval, :issuer
+    attr_reader :interval, :issuer, :image
 
     # @option options [Integer] interval (30) the time interval in seconds for OTP
     #     This defaults to 30 which is standard.
     def initialize(s, options = {})
       @interval = options[:interval] || DEFAULT_INTERVAL
       @issuer = options[:issuer]
+      @image = options[:image]
       super
     end
 
@@ -63,6 +64,7 @@ module ROTP
         secret: secret,
         period: interval == 30 ? nil : interval,
         issuer: issuer,
+        image: image,
         digits: digits == DEFAULT_DIGITS ? nil : digits,
         algorithm: digest.casecmp('SHA1').zero? ? nil : digest.upcase
       }

--- a/spec/lib/rotp/totp_spec.rb
+++ b/spec/lib/rotp/totp_spec.rb
@@ -295,6 +295,23 @@ RSpec.describe ROTP::TOTP do
         expect(params['algorithm'].first).to eq 'SHA256'
       end
     end
+
+    context 'with image' do
+      let(:totp)  { ROTP::TOTP.new 'JBSWY3DPEHPK3PXP', image: 'https://example.com/logo.png' }
+
+      it 'has the correct format' do
+        expect(uri).to match %r{\Aotpauth:\/\/totp/.+}
+      end
+
+      it 'includes the secret as parameter' do
+        expect(params['secret'].first).to eq 'JBSWY3DPEHPK3PXP'
+      end
+
+      it 'includes the image as parameter' do
+        expect(params['image'].first).to eq 'https://example.com/logo.png'
+      end
+    end
+
   end
 
   describe '#now' do


### PR DESCRIPTION
Applications such as FreeOTP support to have an image for your
TOTP entry in the app. This change adds support for the image
parameter.

See https://freeotp.github.io/qrcode.html for more info.