### PR TITLE
URI encode the issuer parameter value

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Google Authenticator.
 
 ```ruby
 totp = ROTP::TOTP.new("base32secret3232", issuer: "My Service")
-totp.provisioning_uri("alice@google.com") # => 'otpauth://totp/My%20Service:alice@google.com?secret=base32secret3232&issuer=My+Service'
+totp.provisioning_uri("alice@google.com") # => 'otpauth://totp/My%20Service:alice@google.com?secret=base32secret3232&issuer=My%20Service'
 
 hotp = ROTP::HOTP.new("base32secret3232", issuer: "My Service")
 hotp.provisioning_uri("alice@google.com", 0) # => 'otpauth://hotp/alice@google.com?secret=base32secret3232&counter=0'

--- a/lib/rotp/totp.rb
+++ b/lib/rotp/totp.rb
@@ -62,7 +62,7 @@ module ROTP
       params = {
         secret: secret,
         period: interval == 30 ? nil : interval,
-        issuer: issuer,
+        issuer: Addressable::URI.encode(issuer),
         digits: digits == DEFAULT_DIGITS ? nil : digits,
         algorithm: digest.casecmp('SHA1').zero? ? nil : digest.upcase
       }

--- a/spec/lib/rotp/totp_spec.rb
+++ b/spec/lib/rotp/totp_spec.rb
@@ -262,6 +262,14 @@ RSpec.describe ROTP::TOTP do
       it 'includes the issuer as parameter' do
         expect(params['issuer'].first).to eq 'FooCo'
       end
+
+      context 'with spaces in issuer' do
+        let(:totp)  { ROTP::TOTP.new 'JBSWY3DPEHPK3PXP', issuer: 'Foo Co' }
+
+        it 'includes the uri encoded issuer as parameter' do
+          expect(params['issuer'].first).to eq 'Foo%20Co'
+        end
+      end
     end
 
     context 'with custom interval' do


### PR DESCRIPTION
https://github.com/google/google-authenticator/wiki/Key-Uri-Format