### PR TITLE
Introducing ROTP::OTP::URI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+services:
+  ruby_2_3:
+    build:
+      context: .
+      dockerfile: Dockerfile-2.3
+    volumes:
+      - "./lib:/usr/src/app/lib"
+      - "./spec:/usr/src/app/spec"
+  ruby_2_5:
+    build:
+      context: .
+      dockerfile: Dockerfile-2.5
+    volumes:
+      - "./lib:/usr/src/app/lib"
+      - "./spec:/usr/src/app/spec"
+  ruby_2_6:
+    build:
+      context: .
+      dockerfile: Dockerfile-2.6
+    volumes:
+      - "./lib:/usr/src/app/lib"
+      - "./spec:/usr/src/app/spec"
+  ruby_2_7:
+    build:
+      context: .
+      dockerfile: Dockerfile-2.7
+    volumes:
+      - "./lib:/usr/src/app/lib"
+      - "./spec:/usr/src/app/spec"

--- a/lib/rotp.rb
+++ b/lib/rotp.rb
@@ -1,4 +1,3 @@
-require 'addressable'
 require 'openssl'
 require 'rotp/base32'
 require 'rotp/otp'

--- a/lib/rotp.rb
+++ b/lib/rotp.rb
@@ -3,6 +3,7 @@ require 'addressable'
 require 'openssl'
 require 'rotp/base32'
 require 'rotp/otp'
+require 'rotp/otp/uri'
 require 'rotp/hotp'
 require 'rotp/totp'
 

--- a/lib/rotp.rb
+++ b/lib/rotp.rb
@@ -1,4 +1,3 @@
-require 'cgi'
 require 'addressable'
 require 'openssl'
 require 'rotp/base32'

--- a/lib/rotp.rb
+++ b/lib/rotp.rb
@@ -1,6 +1,5 @@
 require 'cgi'
 require 'addressable'
-require 'securerandom'
 require 'openssl'
 require 'rotp/base32'
 require 'rotp/otp'

--- a/lib/rotp/base32.rb
+++ b/lib/rotp/base32.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module ROTP
   class Base32
     class Base32Error < RuntimeError; end

--- a/lib/rotp/hotp.rb
+++ b/lib/rotp/hotp.rb
@@ -25,12 +25,7 @@ module ROTP
     # @param [Integer] initial_count starting counter value, defaults to 0
     # @return [String] provisioning uri
     def provisioning_uri(name, initial_count = 0)
-      params = {
-        secret: secret,
-        counter: initial_count,
-        digits: digits == DEFAULT_DIGITS ? nil : digits
-      }
-      encode_params("otpauth://hotp/#{Addressable::URI.escape(name)}", params)
+      OTP::URI.new(self, account_name: name, counter: initial_count).to_s
     end
   end
 end

--- a/lib/rotp/otp.rb
+++ b/lib/rotp/otp.rb
@@ -66,16 +66,6 @@ module ROTP
       result.reverse.join.rjust(padding, 0.chr)
     end
 
-    # A very simple param encoder
-    def encode_params(uri, params)
-      params_str = String.new('?')
-      params.each do |k, v|
-        params_str << "#{k}=#{CGI.escape(v.to_s)}&" if v
-      end
-      params_str.chop!
-      uri + params_str
-    end
-
     # constant-time compare the strings
     def time_constant_compare(a, b)
       return false if a.empty? || b.empty? || a.bytesize != b.bytesize

--- a/lib/rotp/otp/uri.rb
+++ b/lib/rotp/otp/uri.rb
@@ -1,0 +1,79 @@
+module ROTP
+  class OTP
+    # https://github.com/google/google-authenticator/wiki/Key-Uri-Format
+    class URI
+      def initialize(otp, account_name:, counter: nil)
+        @otp = otp
+        @account_name = account_name
+        @counter = counter
+      end
+
+      def to_s
+        "otpauth://#{type}/#{label}?#{parameters}"
+      end
+
+      private
+
+      def algorithm
+        return unless %w[sha256 sha512].include?(@otp.digest)
+
+        @otp.digest.upcase
+      end
+
+      def counter
+        return if @otp.is_a?(TOTP)
+        fail if @counter.nil?
+
+        @counter
+      end
+
+      def digits
+        return if @otp.digits == DEFAULT_DIGITS
+
+        @otp.digits
+      end
+
+      def issuer
+        return if @otp.is_a?(HOTP)
+
+        @otp.issuer&.strip&.tr(':', '_')
+      end
+
+      def label
+        [issuer, @account_name.rstrip]
+          .compact
+          .map { |s| s.tr(':', '_') }
+          .map { |s| ERB::Util.url_encode(s) }
+          .join(':')
+      end
+
+      def parameters
+        {
+          secret: @otp.secret,
+          issuer: issuer,
+          algorithm: algorithm,
+          digits: digits,
+          period: period,
+          counter: counter,
+        }
+          .reject { |_, v| v.nil? }
+          .map { |k, v| "#{k}=#{ERB::Util.url_encode(v)}" }
+          .join('&')
+      end
+
+      def period
+        return if @otp.is_a?(HOTP)
+        return if @otp.interval == DEFAULT_INTERVAL
+
+        @otp.interval
+      end
+
+      def type
+        case @otp
+        when TOTP then 'totp'
+        when HOTP then 'hotp'
+        end
+      end
+    end
+  end
+end

--- a/lib/rotp/totp.rb
+++ b/lib/rotp/totp.rb
@@ -54,19 +54,7 @@ module ROTP
     # @param [String] name of the account
     # @return [String] provisioning URI
     def provisioning_uri(name)
-      # The format of this URI is documented at:
-      # https://github.com/google/google-authenticator/wiki/Key-Uri-Format
-      # For compatibility the issuer appears both before that account name and also in the
-      # query string.
-      issuer_string = issuer.nil? ? '' : "#{Addressable::URI.escape(issuer)}:"
-      params = {
-        secret: secret,
-        period: interval == 30 ? nil : interval,
-        issuer: Addressable::URI.encode(issuer),
-        digits: digits == DEFAULT_DIGITS ? nil : digits,
-        algorithm: digest.casecmp('SHA1').zero? ? nil : digest.upcase
-      }
-      encode_params("otpauth://totp/#{issuer_string}#{Addressable::URI.escape(name)}", params)
+      OTP::URI.new(self, account_name: name).to_s
     end
 
     private

--- a/rotp.gemspec
+++ b/rotp.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'addressable', '~> 2.7'
-
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency 'rspec', '~> 3.5'
   s.add_development_dependency 'simplecov', '~> 0.12'

--- a/spec/lib/rotp/hotp_spec.rb
+++ b/spec/lib/rotp/hotp_spec.rb
@@ -108,29 +108,14 @@ RSpec.describe ROTP::HOTP do
   end
 
   describe '#provisioning_uri' do
-    let(:uri)    { hotp.provisioning_uri('mark@percival') }
-    let(:params) { CGI.parse URI.parse(uri).query }
-
-    it 'has the correct format' do
-      expect(uri).to match %r{\Aotpauth:\/\/hotp.+}
+    it 'accepts the account name' do
+      expect(hotp.provisioning_uri('mark@percival'))
+        .to eq 'otpauth://hotp/mark%40percival?secret=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&counter=0'
     end
 
-    it 'includes the secret as parameter' do
-      expect(params['secret'].first).to eq 'a' * 32
-    end
-
-    context 'with default digits' do
-      it 'does not include digits parameter with default digits' do
-        expect(params['digits'].first).to be_nil
-      end
-    end
-
-    context 'with non-default digits' do
-      let(:hotp) { ROTP::HOTP.new('a' * 32, digits: 8) }
-
-      it 'includes digits parameter' do
-        expect(params['digits'].first).to eq '8'
-      end
+    it 'also accepts a custom counter value' do
+      expect(hotp.provisioning_uri('mark@percival', 17))
+        .to eq 'otpauth://hotp/mark%40percival?secret=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&counter=17'
     end
   end
 end

--- a/spec/lib/rotp/otp/uri_spec.rb
+++ b/spec/lib/rotp/otp/uri_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+RSpec.describe ROTP::OTP::URI do
+  it 'meets basic functionality' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP')
+    uri = described_class.new(otp, account_name: 'alice@google.com')
+    expect(uri.to_s).to eq 'otpauth://totp/alice%40google.com?secret=JBSWY3DPEHPK3PXP'
+  end
+
+  it 'includes issuer' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP', issuer: 'Example')
+    uri = described_class.new(otp, account_name: 'alice@google.com')
+    expect(uri.to_s).to eq 'otpauth://totp/Example:alice%40google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example'
+  end
+
+  it 'encodes the account name' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP', issuer: 'Provider1')
+    uri = described_class.new(otp, account_name: 'Alice Smith')
+    expect(uri.to_s).to eq 'otpauth://totp/Provider1:Alice%20Smith?secret=JBSWY3DPEHPK3PXP&issuer=Provider1'
+  end
+
+  it 'encodes the issuer' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP', issuer: 'Big Corporation')
+    uri = described_class.new(otp, account_name: ' alice@bigco.com')
+    expect(uri.to_s).to eq 'otpauth://totp/Big%20Corporation:%20alice%40bigco.com?secret=JBSWY3DPEHPK3PXP&issuer=Big%20Corporation'
+  end
+
+  it 'includes non-default SHA256 algorithm' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP', digest: 'sha256')
+    uri = described_class.new(otp, account_name: 'alice@google.com')
+    expect(uri.to_s).to eq 'otpauth://totp/alice%40google.com?secret=JBSWY3DPEHPK3PXP&algorithm=SHA256'
+  end
+
+  it 'includes non-default SHA512 algorithm' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP', digest: 'sha512')
+    uri = described_class.new(otp, account_name: 'alice@google.com')
+    expect(uri.to_s).to eq 'otpauth://totp/alice%40google.com?secret=JBSWY3DPEHPK3PXP&algorithm=SHA512'
+  end
+
+  it 'includes non-default 8 digits' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP', digits: 8)
+    uri = described_class.new(otp, account_name: 'alice@google.com')
+    expect(uri.to_s).to eq 'otpauth://totp/alice%40google.com?secret=JBSWY3DPEHPK3PXP&digits=8'
+  end
+
+  it 'includes non-default period for TOTP' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP', interval: 35)
+    uri = described_class.new(otp, account_name: 'alice@google.com')
+    expect(uri.to_s).to eq 'otpauth://totp/alice%40google.com?secret=JBSWY3DPEHPK3PXP&period=35'
+  end
+
+  it 'includes non-default counter for HOTP' do
+    otp = ROTP::HOTP.new('JBSWY3DPEHPK3PXP')
+    uri = described_class.new(otp, account_name: 'alice@google.com', counter: 17)
+    expect(uri.to_s).to eq 'otpauth://hotp/alice%40google.com?secret=JBSWY3DPEHPK3PXP&counter=17'
+  end
+
+  it 'can include all parameters' do
+    otp = ROTP::TOTP.new(
+      'HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ',
+      digest: 'sha512',
+      digits: 8,
+      interval: 60,
+      issuer: 'ACME Co',
+    )
+    uri = described_class.new(otp, account_name: 'john.doe@email.com')
+    expect(uri.to_s).to eq'otpauth://totp/ACME%20Co:john.doe%40email.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm=SHA512&digits=8&period=60'
+  end
+
+  it 'strips leading and trailing whitespace from the issuer' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP', issuer: '  Big Corporation  ')
+    uri = described_class.new(otp, account_name: ' alice@bigco.com')
+    expect(uri.to_s).to eq 'otpauth://totp/Big%20Corporation:%20alice%40bigco.com?secret=JBSWY3DPEHPK3PXP&issuer=Big%20Corporation'
+  end
+
+  it 'strips trailing whitespace from the account name' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP')
+    uri = described_class.new(otp, account_name: '  alice@google.com  ')
+    expect(uri.to_s).to eq 'otpauth://totp/%20%20alice%40google.com?secret=JBSWY3DPEHPK3PXP'
+  end
+
+  it 'replaces colons in the issuer with underscores' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP', issuer: 'Big:Corporation')
+    uri = described_class.new(otp, account_name: 'alice@bigco.com')
+    expect(uri.to_s).to eq 'otpauth://totp/Big_Corporation:alice%40bigco.com?secret=JBSWY3DPEHPK3PXP&issuer=Big_Corporation'
+  end
+
+  it 'replaces colons in the account name with underscores' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP')
+    uri = described_class.new(otp, account_name: 'Alice:Smith')
+    expect(uri.to_s).to eq 'otpauth://totp/Alice_Smith?secret=JBSWY3DPEHPK3PXP'
+  end
+
+  it 'handles email account names with sub-addressing' do
+    otp = ROTP::TOTP.new('JBSWY3DPEHPK3PXP')
+    uri = described_class.new(otp, account_name: 'alice+1234@google.com')
+    expect(uri.to_s).to eq 'otpauth://totp/alice%2B1234%40google.com?secret=JBSWY3DPEHPK3PXP'
+  end
+end

--- a/spec/lib/rotp/totp_spec.rb
+++ b/spec/lib/rotp/totp_spec.rb
@@ -221,87 +221,9 @@ RSpec.describe ROTP::TOTP do
   end
 
   describe '#provisioning_uri' do
-    let(:uri)    { totp.provisioning_uri('mark@percival') }
-    let(:params) { CGI.parse URI.parse(uri).query }
-
-    context 'without issuer' do
-      it 'has the correct format' do
-        expect(uri).to match %r{\Aotpauth:\/\/totp.+}
-      end
-
-      it 'includes the secret as parameter' do
-        expect(params['secret'].first).to eq 'JBSWY3DPEHPK3PXP'
-      end
-    end
-
-    context 'with default digits' do
-      it 'does does not include digits parameter' do
-        expect(params['digits'].first).to be_nil
-      end
-    end
-
-    context 'with non-default digits' do
-      let(:totp)  { ROTP::TOTP.new 'JBSWY3DPEHPK3PXP', digits: 8 }
-
-      it 'does does not include digits parameter' do
-        expect(params['digits'].first).to eq '8'
-      end
-    end
-
-    context 'with issuer' do
-      let(:totp)  { ROTP::TOTP.new 'JBSWY3DPEHPK3PXP', issuer: 'FooCo' }
-
-      it 'has the correct format' do
-        expect(uri).to match %r{\Aotpauth:\/\/totp/FooCo:.+}
-      end
-
-      it 'includes the secret as parameter' do
-        expect(params['secret'].first).to eq 'JBSWY3DPEHPK3PXP'
-      end
-
-      it 'includes the issuer as parameter' do
-        expect(params['issuer'].first).to eq 'FooCo'
-      end
-
-      context 'with spaces in issuer' do
-        let(:totp)  { ROTP::TOTP.new 'JBSWY3DPEHPK3PXP', issuer: 'Foo Co' }
-
-        it 'includes the uri encoded issuer as parameter' do
-          expect(params['issuer'].first).to eq 'Foo%20Co'
-        end
-      end
-    end
-
-    context 'with custom interval' do
-      let(:totp)  { ROTP::TOTP.new 'JBSWY3DPEHPK3PXP', interval: 60 }
-
-      it 'has the correct format' do
-        expect(uri).to match %r{\Aotpauth:\/\/totp.+}
-      end
-
-      it 'includes the secret as parameter' do
-        expect(params['secret'].first).to eq 'JBSWY3DPEHPK3PXP'
-      end
-
-      it 'includes the interval as period parameter' do
-        expect(params['period'].first).to eq '60'
-      end
-    end
-
-    context 'with custom digest' do
-      let(:totp)  { ROTP::TOTP.new 'JBSWY3DPEHPK3PXP', digest: 'sha256' }
-
-      it 'has the correct format' do
-        expect(uri).to match %r{\Aotpauth:\/\/totp.+}
-      end
-
-      it 'includes the secret as parameter' do
-        expect(params['secret'].first).to eq 'JBSWY3DPEHPK3PXP'
-      end
-
-      it 'includes the digest as algorithm parameter' do
-        expect(params['algorithm'].first).to eq 'SHA256'
-      end
+    it 'accepts the account name' do
+      expect(totp.provisioning_uri('mark@percival'))
+        .to eq 'otpauth://totp/mark%40percival?secret=JBSWY3DPEHPK3PXP'
     end
   end
 


### PR DESCRIPTION
Resolves https://github.com/mdp/rotp/issues/98

Working with the v5.1.0 release we had a workaround for spaces encoded as `+` in issuer values. We couldn't upgrade to the v6.0.0 release because of the double encoding bug. Looking over https://github.com/google/google-authenticator/wiki/Key-Uri-Format I felt it was sufficiently awkward enough to warrant it's own home to contain all the non-standard munging.

I added `docker-compose.yml` to assist with testing across all versions.
```
$ docker-compose up
```