### PR TITLE
add drift_window option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ totp.verify("250939", drift_behind: 15, at: now + 35) # => 1474590600
 totp.verify("250939", drift_behind: 15, at: now + 45) # => nil
 ```
 
+In addition to `drift_behind`, there are also `drift_ahead` and `drift_window` (to validate past and future tokens).
+
 ### Generating a Base32 Secret key
 
 ```ruby

--- a/lib/rotp/totp.rb
+++ b/lib/rotp/totp.rb
@@ -31,13 +31,16 @@ module ROTP
     # @param otp [String] the one time password to verify
     # @param drift_behind [Integer] how many seconds to look back
     # @param drift_ahead [Integer] how many seconds to look ahead
+    # @param drift_window [Integer] how many seconds to look ahead and behind
     # @param after [Integer] prevent token reuse, last login timestamp
     # @param at [Time] time at which to generate and verify a particular
     #   otp. default Time.now
     # @return [Integer, nil] the last successful timestamp
     #   interval
-    def verify(otp, drift_ahead: 0, drift_behind: 0, after: nil, at: Time.now)
-      timecodes = get_timecodes(at, drift_behind, drift_ahead)
+    def verify(otp, drift_ahead: 0, drift_behind: 0, drift_window: 0, after: nil, at: Time.now)
+      timecodes = drift_window > 0 ?
+                    get_timecodes(at, drift_window, drift_window) :
+                    get_timecodes(at, drift_behind, drift_ahead)
 
       timecodes = timecodes.select { |t| t > timecode(after) } if after
 

--- a/spec/lib/rotp/totp_spec.rb
+++ b/spec/lib/rotp/totp_spec.rb
@@ -170,6 +170,39 @@ RSpec.describe ROTP::TOTP do
         end
       end
     end
+
+    context 'with a drift window' do
+      let(:verification) { totp.verify token, drift_window: drift_window, at: now }
+      let(:drift_window) { 15 }
+
+      context 'inside of drift window with token ahead' do
+        let(:token) { totp.at TEST_TIME + 20 }
+        it 'is true' do
+          expect(verification).to be_truthy
+        end
+      end
+
+      context 'inside of drift window with token behind' do
+        let(:token) { totp.at TEST_TIME - 20 }
+        it 'is true' do
+          expect(verification).to be_truthy
+        end
+      end
+
+      context 'outside of drift window with token behind too much' do
+        let(:token) { totp.at TEST_TIME - 35 }
+        it 'is nil' do
+          expect(verification).to be_falsey
+        end
+      end
+
+      context 'outside of drift window with token ahead too much' do
+        let(:token) { totp.at TEST_TIME + 35 }
+        it 'is nil' do
+          expect(verification).to be_falsey
+        end
+      end
+    end
   end
 
   describe '#verify with drift and prevent token reuse' do


### PR DESCRIPTION
I've missed this option in the two times I used this (good) library.  A window is also the term used in the RFC (https://tools.ietf.org/html/rfc6238) for the time-step delay. 

I know that is just a shorthand for setting both attributes, so I am ok if you decide to not add complexity.  

Thank you for this great library. :) 