### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/rotp.gemspec
+++ b/rotp.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.authors     = ['Mark Percival']
   s.email       = ['mark@markpercival.us']
-  s.homepage    = 'http://github.com/mdp/rotp'
+  s.homepage    = 'https://github.com/mdp/rotp'
   s.summary     = 'A Ruby library for generating and verifying one time passwords'
   s.description = 'Works for both HOTP and TOTP, and includes QR Code provisioning'
 


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/rotp or some tools or APIs that use the gem's metadata.