### PR TITLE
Allow for Ruby 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### Changelog
 
+### 6.2.0
+
+- Update to expand compatibility with Ruby 3. This was only a change to the
+  gemspec, no code changes were necessary.
+
 ### 6.1.0
 
 - Fixing URI encoding issues again, breaking out into it's own module

--- a/Dockerfile-3.0-rc
+++ b/Dockerfile-3.0-rc
@@ -1,0 +1,12 @@
+FROM ruby:3.0-rc
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app/
+COPY . /usr/src/app
+RUN gem install bundler
+RUN bundle install
+
+CMD ["bundle", "exec", "rspec"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,10 @@ services:
     volumes:
       - "./lib:/usr/src/app/lib"
       - "./spec:/usr/src/app/spec"
+  ruby_3_0_rc:
+    build:
+      context: .
+      dockerfile: Dockerfile-3.0-rc
+    volumes:
+      - "./lib:/usr/src/app/lib"
+      - "./spec:/usr/src/app/spec"

--- a/lib/rotp/version.rb
+++ b/lib/rotp/version.rb
@@ -1,3 +1,3 @@
 module ROTP
-  VERSION = '6.1.1'.freeze
+  VERSION = '6.2.0'.freeze
 end

--- a/lib/rotp/version.rb
+++ b/lib/rotp/version.rb
@@ -1,3 +1,3 @@
 module ROTP
-  VERSION = '6.1.0'.freeze
+  VERSION = '6.1.1'.freeze
 end

--- a/rotp.gemspec
+++ b/rotp.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name        = 'rotp'
   s.version     = ROTP::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.required_ruby_version = '~> 2.3'
+  s.required_ruby_version = '>= 2.3'
   s.license     = 'MIT'
   s.authors     = ['Mark Percival']
   s.email       = ['mark@markpercival.us']


### PR DESCRIPTION
- Update to allow for usage in project on Ruby >= 3.0
- Update Dockerfile tests
- Bump to 6.2.0