### PR TITLE
Update CHANGELOG with Breaking Changes in Version 4 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@
 
 - Simplify API
 - Remove support for Ruby < 2.0
+- BREAKING CHANGE: Removed optional second argument (`padding`) from:
+  - `HOTP#at`
+  - `OTP#generate_otp`
+  - `TOTP#at`
+  - `TOTP#now` (first argument)
 
 #### 3.3.1
 


### PR DESCRIPTION
Addresses breaking changes from https://github.com/mdp/rotp/pull/63