### PR TITLE
Remove obsolete comment

### DIFF
--- a/lib/rotp/otp.rb
+++ b/lib/rotp/otp.rb
@@ -18,7 +18,6 @@ module ROTP
     end
 
     # @param [Integer] input the number used seed the HMAC
-    # @option padded [Boolean] (false) Output the otp as a 0 padded string
     # Usually either the counter, or the computed integer
     # based on the Unix timestamp
     def generate_otp(input)


### PR DESCRIPTION
I just found an outdated comment and removed it.

The `padding` option is unavailable since https://github.com/mdp/rotp/commit/db7cd995b5eecc2ae0038731efad970e6a3235b5#diff-55ac3d4d2ca19a86c547e261d8af1fb6a7f06333865c2d5e5987b90faebe192cL24 .