### PR TITLE
docker-compose.yml: Use ruby-3.0, instead of release candidate versions

### DIFF
--- a/Dockerfile-3.0
+++ b/Dockerfile-3.0
@@ -1,4 +1,4 @@
-FROM ruby:3.0-rc
+FROM ruby:3.0
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,10 +28,10 @@ services:
     volumes:
       - "./lib:/usr/src/app/lib"
       - "./spec:/usr/src/app/spec"
-  ruby_3_0_rc:
+  ruby_3_0:
     build:
       context: .
-      dockerfile: Dockerfile-3.0-rc
+      dockerfile: Dockerfile-3.0
     volumes:
       - "./lib:/usr/src/app/lib"
       - "./spec:/usr/src/app/spec"


### PR DESCRIPTION
This maintenance PR changes the used Dockerfile from release candidates to released versions.

This prepares to add new stable Ruby versions.

This is a follow-up on #105.