### PR TITLE
Add Ruby 3.2 to CI.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,15 +13,14 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.0', '2.7', '2.3', truffleruby-head]
+        ruby-version: ['3.2', '3.1', '3.0', '2.7', '2.3', truffleruby-head]
 
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true
       - name: Run tests
         run: bundle exec rspec


### PR DESCRIPTION
This PR updates the `ruby/setup-ruby` version to `v1` so it picks up both Ruby 3.2 and the logic that installs compatible bundler versions (Ruby 2.3 is not compatible with recent bundler versions).  Moved the gem install to the `setup-ruby` step.

Everything runs green on my fork.