### PR TITLE
chore: Add the .gem file to release for easier publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,17 +26,11 @@ jobs:
       - name: Run tests
         run: bundle exec rspec
         if: ${{ steps.release.outputs.release_created }}
-      # Publish
-      - name: publish gem
-        run: |
-          mkdir -p $HOME/.gem
-          touch $HOME/.gem/credentials
-          chmod 0600 $HOME/.gem/credentials
-          printf -- "---\n:rubygems_api_key: ${RUBYGEMS_AUTH_TOKEN}\n" > $HOME/.gem/credentials
-          gem build *.gemspec
-          gem push *.gem
-        env:
-          # Make sure to update the secret name
-          # if yours isn't named RUBYGEMS_AUTH_TOKEN
-          RUBYGEMS_AUTH_TOKEN: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+      # build gem and add to release
+      - name: Upload Release Artifact
         if: ${{ steps.release.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run:
+          gem build *.gemspec
+          gh release upload ${{ steps.release.outputs.tag_name }} *.gem


### PR DESCRIPTION
- Can't publish to Rubygems via CD with MFA currently, just append the files to the release tag.