### PR TITLE
Add ostruct gem as dependency

### DIFF
--- a/rotp.gemspec
+++ b/rotp.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
+  s.add_dependency 'ostruct'
+
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency 'rspec', '~> 3.5'
   s.add_development_dependency 'simplecov', '~> 0.12'


### PR DESCRIPTION
Close https://github.com/mdp/rotp/issues/137

Ruby 3.5 will remove `ostruct` gem from the bundled gems, so we need to explicitly add it as dependency.