### PR TITLE
Drop usage of `OpenStruct` for Ruby 3.5

### DIFF
--- a/lib/rotp/arguments.rb
+++ b/lib/rotp/arguments.rb
@@ -1,8 +1,9 @@
 require 'optparse'
-require 'ostruct'
 
 module ROTP
   class Arguments
+    Options = Struct.new(:time, :counter, :mode, :digest, :secret, :warnings)
+
     def initialize(filename, arguments)
       @filename = filename
       @arguments = Array(arguments)
@@ -26,7 +27,15 @@ module ROTP
     end
 
     def default_options
-      OpenStruct.new time: true, counter: 0, mode: :time
+      o = Options.new
+      o.time = true
+      o.counter = 0
+      o.mode = :time
+      o
+    end
+
+    def to_h
+      options!.to_h
     end
 
     def parse

--- a/lib/rotp/cli.rb
+++ b/lib/rotp/cli.rb
@@ -31,9 +31,9 @@ module ROTP
       return arguments.to_s if options.mode == :help
 
       if options.mode == :time
-        ROTP::TOTP.new(options.secret, options).now
+        ROTP::TOTP.new(options.secret, options.to_h).now
       elsif options.mode == :hmac
-        ROTP::HOTP.new(options.secret, options).at options.counter
+        ROTP::HOTP.new(options.secret, options.to_h).at options.counter
       end
     end
 


### PR DESCRIPTION
Alternative to #147. I tested this, it works as expected.

It is removed as a default gem in Ruby 3.5 and so will error on that version.

Closes #137