### PR TITLE
Add Ruby 4.0 to the CI matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,11 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      # Include '3.5.0-preview1' to test compatibility with the upcoming Ruby 3.5 release.
       matrix:
-        ruby-version: ['3.5.0-preview1', '3.4', '3.3', '3.2', '3.0', '2.7', '2.3', 'truffleruby-head']
+        ruby-version: ['4.0', '3.4', '3.3', '3.2', '3.0', '2.7', '2.3', 'truffleruby-head']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/spec/lib/rotp/hotp_spec.rb
+++ b/spec/lib/rotp/hotp_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe ROTP::HOTP do
 
   describe '#provisioning_uri' do
     let(:hotp) { ROTP::HOTP.new('a' * 32, name: "m@mdp.im") }
-    let(:params) { CGI.parse URI.parse(uri).query }
+    let(:params) { query_params_for(uri) }
 
     it 'created from the otp instance data' do
       expect(hotp.provisioning_uri())

--- a/spec/lib/rotp/totp_spec.rb
+++ b/spec/lib/rotp/totp_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe ROTP::TOTP do
 
 
   describe '#provisioning_uri' do
-    let(:params) { CGI.parse URI.parse(uri).query }
+    let(:params) { query_params_for(uri) }
 
     context "with a provided name on the TOTP instance" do
       let(:totp) { ROTP::TOTP.new(TEST_SECRET, name: "m@mdp.im") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ SimpleCov.start do
   add_filter '/spec/'
 end
 
+require 'uri'
 require 'rotp'
 require 'timecop'
 
@@ -14,6 +15,12 @@ RSpec.configure do |config|
 
   config.before do
     Timecop.return
+  end
+end
+
+def query_params_for(uri)
+  URI.decode_www_form(URI.parse(uri).query).each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(key, value), params|
+    params[key] << value
   end
 end
 


### PR DESCRIPTION
`CGI.parse` is no longer bundled in Ruby 4.0.

ref: https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/#stdlib-compatibility-issues

This causes tests to fail on Ruby 4.0, so update the tests to avoid using CGI.parse.

Also upgrade actions/checkout to the latest version.